### PR TITLE
Move configuration to the plugin.xml

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+SampleApp/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "localytics-cordova",
-  "version": "3.9.0-cmt",
+  "version": "3.9.0",
   "description": "Localytics Plugin for Cordova/PhoneGap",
   "cordova": {
     "id": "com.localytics.phonegap.LocalyticsPlugin",
@@ -21,12 +21,10 @@
     "analytics",
     "push messaging"
   ],
-  "engines": [
-    {
-      "name": "cordova",
-      "version": ">=3.0.0"
-    }
-  ],
+  "engines": [{
+    "name": "cordova",
+    "version": ">=3.0.0"
+  }],
   "author": "Localytics",
   "license": "SEE LICENSE IN 'LICENSE' file",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "localytics-cordova",
-  "version": "3.8.3",
+  "version": "3.9.0-cmt",
   "description": "Localytics Plugin for Cordova/PhoneGap",
   "cordova": {
     "id": "com.localytics.phonegap.LocalyticsPlugin",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="com.localytics.phonegap.LocalyticsPlugin"  xmlns:android="http://schemas.android.com/apk/res/android" version="1.0.0">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="com.localytics.phonegap.LocalyticsPlugin"  xmlns:android="http://schemas.android.com/apk/res/android" version="3.9.0-cmt">
     <name>Localytics</name>
     <description>Localytics Plugin for Cordova/PhoneGap</description>
     <license>Apache 2.0</license>
@@ -34,7 +34,6 @@
     </platform>
 
     <platform name="android">
-        <framework src="com.android.support:support-v4:+" />
 
         <config-file target="config.xml" parent="/*">
             <feature name="LocalyticsPlugin" >
@@ -45,6 +44,15 @@
         <config-file target="AndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.INTERNET" />
             <uses-permission android:name="android.permission.WAKE_LOCK" />
+        </config-file>
+
+        <config-file target="AndroidManifest.xml" parent="/manifest/application">
+            <activity android:name="com.localytics.android.PushTrackingActivity" />
+            <receiver android:name="com.localytics.android.ReferralReceiver" android:exported="true">
+                <intent-filter>
+                  <action android:name="com.android.vending.INSTALL_REFERRER" />
+                </intent-filter>
+            </receiver>
         </config-file>
 
         <source-file src="src/android/localytics.jar" target-dir="libs/" />


### PR DESCRIPTION
- Move the configuration into the plugin.xml so that it will be added automagically to AndroidManifest in case you are generating this file on a Jenkins server for instance.
- Remove the double reference to the <framework src="com.android.support:support-v4:+" />
- Align the version with the package.json